### PR TITLE
Revert "close(pr): update registry.access.redhat.com/ubi9/openjdk-25-runtime docker tag to v1.24"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/openjdk-25-runtime:1.24
+FROM registry.access.redhat.com/ubi9/openjdk-25-runtime:1.24-2.1779791370
 
 
 ENV LANGUAGE='en_US:en'


### PR DESCRIPTION
Reverts onecx/docker-quarkus-jvm#71